### PR TITLE
Add flake.nix to support building this project under nix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /dist/
 /nwg_displays/resources/#main.glade#
 /nwg_displays/__pycache__
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1673362319,
+        "narHash": "sha256-Pjp45Vnj7S/b3BRpZEVfdu8sqqA6nvVjvYu59okhOyI=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "82c16f1682cf50c01cb0280b38a1eed202b3fe9f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1673540789,
+        "narHash": "sha256-xqnxBOK3qctIeUVxecydrEDbEXjsvHCPGPbvsl63M/U=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0f213d0fee84280d8c3a97f7469b988d6fe5fcdf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1672350804,
+        "narHash": "sha256-jo6zkiCabUBn3ObuKXHGqqORUMH27gYDIFFfLq5P4wg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "677ed08a50931e38382dbef01cba08a8f7eac8f6",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+  description = "An output management utility for the sway Wayland compositor, inspired by wdisplays and wlay."
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs@{ self, flake-parts, nixpkgs, ...  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      # TODO: This probably works on more linux architechtures but I haven't tested them
+      systems = ["x86_64-linux"];
+      imports = [];
+
+      perSystem = { config, inputs', pkgs, system, ... }: 
+        {
+          packages = {
+            nwg-displays = pkgs.python3Packages.buildPythonApplication
+            rec {
+              pname = "nwg-displays";
+              version = "0.1.4";
+              doCheck = false;
+              src = self;
+
+              nativeBuildInputs = [
+                pkgs.wrapGAppsHook
+                pkgs.gobject-introspection
+              ];
+
+              buildInputs = with pkgs; [
+                gtk3
+              ];
+
+              propagatedBuildInputs = with pkgs; [
+                pango
+                gtk-layer-shell
+                gdk-pixbuf
+                atk
+                python310Packages.i3ipc
+                python310Packages.pygobject3
+                python310Packages.gst-python
+              ];
+
+              dontWrapGApps = true;
+
+              preFixup = ''
+                makeWrapperArgs+=("''${gappsWrapperArgs[@]}");
+              '';
+            };
+          };
+        };
+      };
+}


### PR DESCRIPTION
Adds in a flake.nix file that allows users of the [Nix](https://nixos.org/) package manager to build and install nwg-displays via the [Flakes](https://www.tweag.io/blog/2020-05-25-flakes/) feature.