### PR TITLE
Add missing semicolon in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "An output management utility for the sway Wayland compositor, inspired by wdisplays and wlay."
+  description = "An output management utility for the sway Wayland compositor, inspired by wdisplays and wlay.";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";


### PR DESCRIPTION
I'm unable to build this flake because of the following error:
```
❯ nix profile install git+https://github.com/nwg-piotr/nwg-displays
error: syntax error, unexpected '=', expecting ';'

       at /nix/store/cx2p7mqzx7jl4r33g4ywgqnny1b142m9-source/flake.nix:3:10:

            2|   description = "An output management utility for the sway Wayland compositor, inspired by wdisplays and wlay."
            3|   inputs = {
             |          ^
            4|     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
```

There might be other issues hidden behind this one, I haven't had time to check.