### PR TITLE
flake: Set `nwg-displays` as the default package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,8 @@
 
       perSystem = { config, inputs', pkgs, system, ... }: 
         {
-          packages = {
+          packages = rec {
+            default = nwg-displays;
             nwg-displays = pkgs.python3Packages.buildPythonApplication
             rec {
               pname = "nwg-displays";


### PR DESCRIPTION
This is just a quality-of-life change, so that instead of running:
```
nix profile install "git+https://github.com/nwg-piotr/nwg-displays#nwg-displays
```
... one can simply run:
```
nix profile install "git+https://github.com/nwg-piotr/nwg-displays
```