### PR TITLE
fix(flake): use the same Python version for buildPythonApplication and for propagatedBuildInputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673540789,
-        "narHash": "sha256-xqnxBOK3qctIeUVxecydrEDbEXjsvHCPGPbvsl63M/U=",
+        "lastModified": 1698924604,
+        "narHash": "sha256-GCFbkl2tj8fEZBZCw3Tc0AkGo0v+YrQlohhEGJ/X4s0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0f213d0fee84280d8c3a97f7469b988d6fe5fcdf",
+        "rev": "fa804edfb7869c9fb230e174182a8a1a7e512c40",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       systems = ["x86_64-linux"];
       imports = [];
 
-      perSystem = { config, inputs', pkgs, system, ... }: 
+      perSystem = { config, inputs', pkgs, system, ... }:
         {
           packages = rec {
             default = nwg-displays;
@@ -37,9 +37,9 @@
                 gtk-layer-shell
                 gdk-pixbuf
                 atk
-                python310Packages.i3ipc
-                python310Packages.pygobject3
-                python310Packages.gst-python
+                python3Packages.i3ipc
+                python3Packages.pygobject3
+                python3Packages.gst-python
               ];
 
               dontWrapGApps = true;


### PR DESCRIPTION
Flake build with overriding with newer nixpkgs input (github:nixos/nixpkgs/nixpkgs-unstable or master) is failing since the default python3Packages is 3.11.