### PR TITLE
fix(hyprland): strip adapter info from output descriptions

### DIFF
--- a/nwg_displays/main.py
+++ b/nwg_displays/main.py
@@ -862,7 +862,8 @@ def apply_settings(display_buttons, outputs_activity, outputs_path, use_desc=Fal
             if db.transform != "normal":
                 lines.append("monitor={},transform,{}".format(name, transforms[db.transform]))
 
-            if name in outputs_activity and not outputs_activity[name]:
+            # avoid looking up the hardware name
+            if db.name in outputs_activity and not outputs_activity[db.name]:
                 lines.append("monitor={},disable".format(name))
 
         print("[Saving]")

--- a/nwg_displays/tools.py
+++ b/nwg_displays/tools.py
@@ -112,6 +112,10 @@ def list_outputs():
             if not line.startswith(" "):
                 name = line.split()[0]
                 description = line.replace(name, "")[2:-4]
+                # It may happen that the description contains the adapter translations in parens, e.g.:
+                # LG Electronics LG ULTRAGEAR 1231234F (DP-2 via HDMI)"
+                description = description.split(" (")[0]
+                # Just grab the pure description, e.g. "LG Electronics LG ULTRAGEAR 1231234F"
                 outputs_dict[name] = {"description": description,
                                       "active": False,
                                       "focused": False,


### PR DESCRIPTION
Ensure that the display description is parsed without any adapter translations or parenthetical remarks by trimming anything following a parenthesis in the description string. This change fixes the invalidation of hardware description strings in hyprland.


wlr-randr (and hyprctl monitors) may return attional adapter information behind tyhe description, which invalidates the hardware description string, e.g.
LG Electronics LG ULTRAGEAR 1231234F (DP-2 via HDMI) -> desc:LG Electronics LG ULTRAGEAR 1231234F (DP-2, 