### PR TITLE
Check `output_path` exists before reading in backup

### DIFF
--- a/nwg_displays/main.py
+++ b/nwg_displays/main.py
@@ -831,7 +831,13 @@ def apply_settings(display_buttons, outputs_activity, outputs_path, use_desc=Fal
         for line in lines:
             print(line)
 
-        backup = load_text_file(outputs_path).splitlines()
+        # Check if the outputs file exists
+        if os.path.isfile(outputs_path):
+            # Load a backup to restore settings if needed
+            backup = load_text_file(outputs_path).splitlines()
+        else:
+            backup = []
+
         save_list_to_text_file(lines, outputs_path)
 
         print("[Executing]")


### PR DESCRIPTION
* If the `output_path` does not yet exist, pressing Apply will throw an AttributeError because `load_text_file(...)` returns null.
* With this change, we check for the existence of the file before trying to load the backup. If it does not exist, we fallback to an empty array.

```[Errno 2] No such file or directory: '/home/dylan/.config/sway/outputs'
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/nwg_displays/main.py", line 519, in on_apply_button
    apply_settings(display_buttons, outputs_activity, outputs_path, use_desc=config["use-desc"])
  File "/usr/lib/python3.11/site-packages/nwg_displays/main.py", line 834, in apply_settings
    backup = load_text_file(outputs_path).splitlines()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'splitlines'
```

**Steps to reproduce**

1. Delete $HOME/sway/outputs or equivalent `output_path` for the window manager in use.
2. Launch nwg-displays via command-line and press apply.
3. Observe that the UI does not update. In the console, observe the AttributeError due to file not found.