### PR TITLE
Improve disabling/enabling monitors on Hyprland

### DIFF
--- a/nwg_displays/main.py
+++ b/nwg_displays/main.py
@@ -890,7 +890,7 @@ def create_confirm_win(backup, path):
 
     GtkLayerShell.init_for_window(confirm_win)
     GtkLayerShell.set_layer(confirm_win, GtkLayerShell.Layer.OVERLAY)
-    GtkLayerShell.set_keyboard_interactivity(confirm_win, True)
+    # GtkLayerShell.set_keyboard_mode(confirm_win, GtkLayerShell.KeyboardMode.ON_DEMAND)
 
     confirm_win.set_resizable(False)
     confirm_win.set_modal(True)

--- a/nwg_displays/main.py
+++ b/nwg_displays/main.py
@@ -430,9 +430,6 @@ def on_transform_changed(*args):
 def on_dpms_toggled(widget):
     if selected_output_button:
         selected_output_button.dpms = widget.get_active()
-    if hypr:
-        cmd = "on" if widget.get_active() else "off"
-        hyprctl(f"dispatch dpms {cmd} {selected_output_button.name}")
 
 
 def on_use_desc_toggled(widget):
@@ -874,6 +871,9 @@ def apply_settings(display_buttons, outputs_activity, outputs_path, use_desc=Fal
             # avoid looking up the hardware name
             if db.name in outputs_activity and not outputs_activity[db.name]:
                 lines.append("monitor={},disable".format(name))
+
+            cmd = "on" if db.dpms else "off"
+            hyprctl(f"dispatch dpms {cmd} {db.name}")
 
         print("[Saving]")
         for line in lines:

--- a/nwg_displays/main.py
+++ b/nwg_displays/main.py
@@ -430,6 +430,9 @@ def on_transform_changed(*args):
 def on_dpms_toggled(widget):
     if selected_output_button:
         selected_output_button.dpms = widget.get_active()
+    if hypr:
+        cmd = "on" if widget.get_active() else "off"
+        hyprctl(f"dispatch dpms {cmd} {selected_output_button.name}")
 
 
 def on_use_desc_toggled(widget):
@@ -1093,11 +1096,13 @@ def main():
 
     global form_dpms
     form_dpms = builder.get_object("dpms")
-    if sway:
-        form_dpms.set_tooltip_text(voc["dpms-tooltip"])
-        form_dpms.connect("toggled", on_dpms_toggled)
-    else:
-        form_dpms.set_sensitive(False)
+    form_dpms.set_tooltip_text(voc["dpms-tooltip"])
+    form_dpms.connect("toggled", on_dpms_toggled)
+    # if sway:
+    #     form_dpms.set_tooltip_text(voc["dpms-tooltip"])
+    #     form_dpms.connect("toggled", on_dpms_toggled)
+    # else:
+    #     form_dpms.set_sensitive(False)
 
     global form_adaptive_sync
     form_adaptive_sync = builder.get_object("adaptive-sync")

--- a/nwg_displays/tools.py
+++ b/nwg_displays/tools.py
@@ -165,6 +165,7 @@ def list_outputs():
             outputs_dict[m["name"]]["transform"] = transforms[m["transform"]]
             outputs_dict[m["name"]]["scale"] = m["scale"]
             outputs_dict[m["name"]]["focused"] = m["focused"]
+            outputs_dict[m["name"]]["dpms"] = m["dpmsStatus"]
 
     else:
         eprint("This program only supports sway and Hyprland, and we seem to be elsewhere, terminating.")

--- a/nwg_displays/tools.py
+++ b/nwg_displays/tools.py
@@ -139,6 +139,14 @@ def list_outputs():
                     modes.append(mode)
                     outputs_dict[name]["modes"] = modes
 
+                    # We need to detect current mode here, as values from hyprctl are not exactly the same,
+                    # and we'll be unable to preselect current mode in modes combo
+                    if "current" in line:
+                        w_h = line.split()[0].split('x')
+                        outputs_dict[name]["physical-width"] = int(w_h[0])
+                        outputs_dict[name]["physical-height"] = int(w_h[1])
+                        outputs_dict[name]["refresh"] = float(parts[2])
+
             # This may or may not work. We'll try to read the value again from hyprctl -j monitors.
             if name and line.startswith("  Adaptive Sync:"):
                 outputs_dict[name]["adaptive_sync_status"] = line.split()[1]
@@ -157,11 +165,11 @@ def list_outputs():
             outputs_dict[m["name"]]["description"] = f'{m["make"]} {m["model"]} {m["serial"]}'
             outputs_dict[m["name"]]["x"] = int(m["x"])
             outputs_dict[m["name"]]["y"] = int(m["y"])
-            outputs_dict[m["name"]]["refresh"] = m["refreshRate"]
+            # outputs_dict[m["name"]]["refresh"] = m["refreshRate"]
             outputs_dict[m["name"]]["logical-width"] = m["width"]
             outputs_dict[m["name"]]["logical-height"] = m["height"]
-            outputs_dict[m["name"]]["physical-width"] = m["width"] / m["scale"]
-            outputs_dict[m["name"]]["physical-height"] = m["height"] / m["scale"]
+            # outputs_dict[m["name"]]["physical-width"] = m["width"] / m["scale"]
+            # outputs_dict[m["name"]]["physical-height"] = m["height"] / m["scale"]
             outputs_dict[m["name"]]["transform"] = transforms[m["transform"]]
             outputs_dict[m["name"]]["scale"] = m["scale"]
             outputs_dict[m["name"]]["focused"] = m["focused"]

--- a/nwg_displays/tools.py
+++ b/nwg_displays/tools.py
@@ -174,6 +174,8 @@ def list_outputs():
             outputs_dict[m["name"]]["scale"] = m["scale"]
             outputs_dict[m["name"]]["focused"] = m["focused"]
             outputs_dict[m["name"]]["dpms"] = m["dpmsStatus"]
+            # to identify Gdk.Monitor
+            outputs_dict[m["name"]]["model"] = m["model"]
 
     else:
         eprint("This program only supports sway and Hyprland, and we seem to be elsewhere, terminating.")
@@ -184,9 +186,10 @@ def list_outputs():
     for i in range(display.get_n_monitors()):
         monitor = display.get_monitor(i)
         geometry = monitor.get_geometry()
-
+        # This will fail for 2 displays of the same model and coordinates, but we have no better way
         for key in outputs_dict:
-            if int(outputs_dict[key]["x"]) == geometry.x and int(outputs_dict[key]["y"]) == geometry.y:
+            if (int(outputs_dict[key]["x"]) == geometry.x and int(outputs_dict[key]["y"]) == geometry.y
+                    and outputs_dict[key]["model"] == monitor.get_model()):
                 outputs_dict[key]["monitor"] = monitor
                 break
 

--- a/nwg_displays/tools.py
+++ b/nwg_displays/tools.py
@@ -98,7 +98,7 @@ def list_outputs():
 
         eprint("Running on Hyprland")
         # This will be tricky. The `hyprctl monitors` command returns just a part of the output attributes we need.
-        # The `wlr-randr` command returns almost everything, but not "focused". We need to use both commands. :/
+        # We need `wlr-randr` command to get modes, current mode and focused status. We need to use both commands. :/
 
         # 1. Mirroring is impossible to check in any way. We need to parse back the monitors.conf file, and it sucks.
         mirrors = {}
@@ -122,7 +122,7 @@ def list_outputs():
                 name = line.split()[0]
 
                 outputs_dict[name]["modes"] = []
-                outputs_dict[name]["scale_filter"] = None
+                outputs_dict[name]["scale_filter"] = None  # This value does not exist in Hyprland
                 outputs_dict[name]["dpms"] = None
                 outputs_dict[name]["mirror"] = ""
                 outputs_dict[name]["monitor"] = None

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(f_name):
 
 setup(
     name='nwg-displays',
-    version='0.3.11',
+    version='0.3.12',
     description='nwg-shell output configuration utility',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
From now on we rely on difference between `hyprctl monitors all` and `hyprctl monitors` output to detect disabled monitors. On thing remains unresolved: disabled monitors in `hyprctl monitors all` have always x and y coordinate equal 0, so we have no way to restore their previous position.

Also: the DPMS check button work on Hyprland now. As Hyprland does not save this value in monitor settings, we use the dispatcher: ` hyprctl dispatch dpms on|off <monitor-name>`.

Closes #42 