### PR TITLE
use hyprland monitor descriptions directly

### DIFF
--- a/nwg_displays/tools.py
+++ b/nwg_displays/tools.py
@@ -161,7 +161,7 @@ def list_outputs():
             outputs_dict[m["name"]]["focused"] = m["focused"]
             outputs_dict[m["name"]]["adaptive_sync_status"] = "enabled" if m["vrr"] else "disabled"
 
-            outputs_dict[m["name"]]["description"] = f'{m["make"]} {m["model"]} {m["serial"]}'
+            outputs_dict[m["name"]]["description"] = f'{m["description"]}'
             outputs_dict[m["name"]]["x"] = int(m["x"])
             outputs_dict[m["name"]]["y"] = int(m["y"])
             # outputs_dict[m["name"]]["refresh"] = m["refreshRate"]


### PR DESCRIPTION
Hyprland strips commas from their monitor descriptions. Therefore, we should use the sanitized descriptions directly instead of building the string from scratch.

Note that descriptions with commas won't work before hyprwm/Hyprland#4970 is merged.