### PR TITLE
Renames generically named sway functions

### DIFF
--- a/nwg_displays/main.py
+++ b/nwg_displays/main.py
@@ -621,10 +621,10 @@ def handle_keyboard(window, event):
         window.close()
 
 
-def create_workspaces_window(btn):
+def create_workspaces_window_sway(btn):
     global sway_config_dir
     global workspaces
-    workspaces = load_workspaces(os.path.join(sway_config_dir, "workspaces"), use_desc=config["use-desc"])
+    workspaces = load_workspaces_sway(os.path.join(sway_config_dir, "workspaces"), use_desc=config["use-desc"])
     old_workspaces = workspaces.copy()
     global dialog_win
     if dialog_win:
@@ -665,7 +665,7 @@ def create_workspaces_window(btn):
     btn_apply = Gtk.Button()
     btn_apply.set_label(voc["apply"])
     if sway_config_dir:
-        btn_apply.connect("clicked", on_workspaces_apply_btn, dialog_win, old_workspaces)
+        btn_apply.connect("clicked", on_workspaces_apply_btn_sway, dialog_win, old_workspaces)
     else:
         btn_apply.set_sensitive(False)
         btn_apply.set_tooltip_text("Config dir not found")
@@ -752,7 +752,7 @@ def close_dialog(w, win):
     win.close()
 
 
-def on_workspaces_apply_btn(w, win, old_workspaces):
+def on_workspaces_apply_btn_sway(w, win, old_workspaces):
     global workspaces
     if workspaces != old_workspaces:
         save_workspaces(workspaces, os.path.join(sway_config_dir, "workspaces"), use_desc=config["use-desc"])
@@ -1220,7 +1220,7 @@ def main():
     form_workspaces.set_label(voc["workspaces"])
     form_workspaces.set_tooltip_text(voc["workspaces-tooltip"])
     if sway:
-        form_workspaces.connect("clicked", create_workspaces_window)
+        form_workspaces.connect("clicked", create_workspaces_window_sway)
     elif hypr:
         form_workspaces.connect("clicked", create_workspaces_window_hypr)
 

--- a/nwg_displays/tools.py
+++ b/nwg_displays/tools.py
@@ -334,7 +334,7 @@ def load_text_file(path):
         return None
 
 
-def load_workspaces(path, use_desc=False):
+def load_workspaces_sway(path, use_desc=False):
     result = {}
     try:
         with open(path, 'r') as file:


### PR DESCRIPTION
There were some functions that had `_hypr` and the sway equivalent did not have `_sway` at the end. This leads the reader of the code to believe that it is generically used for both wayland compositors. So I have renamed all occurrences to respect that all sway related functions shall end with `_sway` instead.