### PR TITLE
add config for confirmation timeout

### DIFF
--- a/nwg_displays/main.py
+++ b/nwg_displays/main.py
@@ -929,7 +929,10 @@ def create_confirm_win(backup, path):
     lbl = Gtk.Label.new("{}?".format(voc["keep-current-settings"]))
     grid.attach(lbl, 0, 0, 2, 1)
 
-    cnt_lbl = Gtk.Label.new("10")
+    global counter
+    counter = config["confirm-timeout"]
+
+    cnt_lbl = Gtk.Label.new(str(counter))
     grid.attach(cnt_lbl, 0, 1, 2, 1)
     btn_restore = Gtk.Button.new_with_label(voc["restore"])
 
@@ -942,8 +945,6 @@ def create_confirm_win(backup, path):
 
     confirm_win.show_all()
 
-    global counter
-    counter = 10
     global src_tag
     src_tag = GLib.timeout_add_seconds(1, count_down, cnt_lbl, backup, path)
 

--- a/nwg_displays/tools.py
+++ b/nwg_displays/tools.py
@@ -284,7 +284,8 @@ def config_keys_missing(config, config_file):
                 "snap-threshold": 10,
                 "indicator-timeout": 500,
                 "custom-mode": [],
-                "use-desc": False, }
+                "use-desc": False,
+                "confirm-timeout": 10, }
     for key in defaults:
         if key not in config:
             config[key] = defaults[key]


### PR DESCRIPTION
Sometimes it takes the compositor some time to adjust the display settings, so it's nice to have adjustable timeout for the confirmation window.