### PR TITLE
Fix issue preventing text entry in refresh rate field.

### DIFF
--- a/nwg_displays/main.py
+++ b/nwg_displays/main.py
@@ -516,8 +516,6 @@ def on_refresh_changed(widget):
     if selected_output_button:
         selected_output_button.refresh = widget.get_value()
 
-        update_form_from_widget(selected_output_button)
-
 
 def on_mode_changed(widget):
     if selected_output_button and not on_mode_changed_silent:


### PR DESCRIPTION
This fixes an issue which was preventing me from manually entering a refresh rate into the text box.

Previously, there were no issues adjusting the refresh rate with the +/- buttons nor did I have issues entering text into the height or width fields. But it was just the refresh rate field that wouldn't change.

I've removed  `update_form_from_widget` in line with `on_width_changed` and `on_height_changed`.