### PR TITLE
fix: add missing import

### DIFF
--- a/nwg_displays/main.py
+++ b/nwg_displays/main.py
@@ -16,6 +16,7 @@ Thank you, Kurt Jacobson!
 import argparse
 import os.path
 import sys
+import stat
 
 import gi
 


### PR DESCRIPTION
The changes introduced in https://github.com/nwg-piotr/nwg-displays/pull/97 require stats import.

Fixes `ERROR: Failed to make file writable: name 'stat' is not defined` error on some cases.