### PR TITLE
Include the missing package data in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     description="nwg-shell output configuration utility",
     packages=find_packages(),
     include_package_data=True,
-    package_data={"": ["resources/*", "langs/*"]},
+    package_data={"": ["resources/*", "langs/*", "scripts/*", "settings_applier/*", "wallpaper_manager/*"]},
     url="https://github.com/nwg-piotr/nwg-displays",
     license="MIT",
     author="Piotr Miller",


### PR DESCRIPTION
I am trying to package it to Guix ([here](https://codeberg.org/guix/guix/pulls/7644) is the PR). When launching `nwg-displays-toggle-wallpapers` I got this error:

```
Traceback (most recent call last):
File "/gnu/store/838jsc844sndrs6dvp3zgkrnsmxgi69c-nwg-displays-0.3.28/bin/.nwg-displays-toggle-wallpapers-real", line 6, in <module>
obj = importlib.import_module('nwg_displays.scripts.toggle_profile_wallpapers')
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/gnu/store/fg57qxli2l7ppc8198vfckln7jimsjl7-python-3.11.14/lib/python3.11/importlib/__init__.py", line 126, in import_module
return _bootstrap._gcd_import(name[level:], package, level)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
File "<frozen importlib._bootstrap>", line 1126, in _find_and_load_unlocked
File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
File "<frozen importlib._bootstrap>", line 1140, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'nwg_displays.scripts'
```

This patch fixes this error.