### PR TITLE
add:hdr for hyprland 

### DIFF
--- a/nwg_displays/main.py
+++ b/nwg_displays/main.py
@@ -122,6 +122,9 @@ form_version = None
 form_mirror = None
 form_ten_bit = None
 form_profile_wallpapers = None
+form_cm = None
+form_sdr_brightness = None
+form_sdr_saturation = None
 
 dialog_win = None
 confirm_win = None
@@ -379,6 +382,9 @@ def update_form_from_widget(widget):
 
     on_mode_changed_silent = False
 
+    form_cm.set_active_id(widget.cm)
+    form_sdr_brightness.set_value(widget.sdr_brightness)
+    form_sdr_saturation.set_value(widget.sdr_saturation)
 
 class DisplayButton(Gtk.Button):
     def __init__(
@@ -401,6 +407,9 @@ class DisplayButton(Gtk.Button):
         custom_mode_status,
         focused,
         monitor,
+        cm,
+        sdr_brightness=1.0,
+        sdr_saturation=1.0,
         mirror="",
     ):
         super().__init__()
@@ -429,7 +438,9 @@ class DisplayButton(Gtk.Button):
         self.focused = focused
         self.mirror = mirror
         self.ten_bit = ten_bit
-
+        self.cm = cm
+        self.sdr_brightness = sdr_brightness
+        self.sdr_saturation = sdr_saturation
         # Button properties
         self.selected = False
         self.set_can_focus(False)
@@ -599,6 +610,25 @@ def on_refresh_changed(widget):
 
         update_form_from_widget(selected_output_button)
 
+def on_sdr_saturation_changed(widget):
+    if selected_output_button:
+        selected_output_button.sdr_saturation = widget.get_value()
+
+        update_form_from_widget(selected_output_button)
+
+
+def on_sdr_brightness_changed(widget):
+    if selected_output_button:
+        selected_output_button.sdr_brightness = widget.get_value()
+
+        update_form_from_widget(selected_output_button)
+
+
+def on_cm_changed(widget):
+    if selected_output_button:
+        selected_output_button.cm = widget.get_active_id()
+        update_form_from_widget(selected_output_button)
+
 
 def on_mode_changed(widget):
     if selected_output_button and not on_mode_changed_silent:
@@ -689,6 +719,9 @@ def create_display_buttons():
             item["focused"],
             item["monitor"],
             mirror=item["mirror"],
+            cm=item["cm"],
+            sdr_brightness=item["sdr_brightness"],
+            sdr_saturation=item["sdr_saturation"],
         )
 
         display_buttons.append(b)
@@ -1356,6 +1389,32 @@ def main():
 
     global fixed
     fixed = builder.get_object("fixed")
+
+    if hypr:
+        global form_cm
+        global form_sdr_brightness
+        global form_sdr_saturation
+        form_cm = builder.get_object("cm")
+        form_cm.set_wrap_width(1)
+        form_sdr_brightness = builder.get_object("sdr-brightness")
+        form_sdr_saturation = builder.get_object("sdr-saturation")
+        builder.get_object("lbl-cm").show()
+        builder.get_object("lbl-sdr-brightness").show()
+        builder.get_object("lbl-sdr-saturation").show()
+        adj = Gtk.Adjustment(
+            lower=0, upper=4, step_increment=0.01, page_increment=10, page_size=1
+        )
+        adj1 = Gtk.Adjustment(
+            lower=0, upper=4, step_increment=0.01, page_increment=10, page_size=1
+        )
+        form_sdr_brightness.configure(adj, 1, 2)
+        form_sdr_saturation.configure(adj1, 1, 2)
+        form_sdr_brightness.connect("changed", on_sdr_brightness_changed)
+        form_sdr_saturation.connect("changed", on_sdr_saturation_changed)
+        form_cm.connect("changed", on_cm_changed)
+        form_cm.show()
+        form_sdr_brightness.show()
+        form_sdr_saturation.show()
 
     create_display_buttons()
 

--- a/nwg_displays/resources/main.glade
+++ b/nwg_displays/resources/main.glade
@@ -54,7 +54,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <child>
-                      <!-- n-columns=8 n-rows=6 -->
+                      <!-- n-columns=8 n-rows=7 -->
                       <object class="GtkGrid" id="grid">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
@@ -142,6 +142,78 @@
                           <packing>
                             <property name="left-attach">6</property>
                             <property name="top-attach">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="lbl-cm">
+                            <property name="can-focus">True</property>
+                            <property name="no-show-all">True</property>
+                            <property name="halign">end</property>
+                            <property name="label">CM:</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">5</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkComboBoxText" id="cm">
+                            <property name="can-focus">True</property>
+                            <property name="no-show-all">True</property>
+                            <property name="double-buffered">False</property>
+                            <items>
+                              <item id="srgb" translatable="yes">srgb</item>
+                              <item id="hdr" translatable="yes">hdr</item>
+                              <item id="hdredid" translatable="yes">hdredid</item>
+                            </items>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">5</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="lbl-sdr-brightness">
+                            <property name="can-focus">True</property>
+                            <property name="no-show-all">True</property>
+                            <property name="halign">end</property>
+                            <property name="label">SDR Brightness:</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">2</property>
+                            <property name="top-attach">5</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSpinButton" id="sdr-brightness">
+                            <property name="can-focus">True</property>
+                            <property name="no-show-all">True</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">3</property>
+                            <property name="top-attach">5</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="lbl-sdr-saturation">
+                            <property name="can-focus">True</property>
+                            <property name="no-show-all">True</property>
+                            <property name="halign">end</property>
+                            <property name="label">SDR Saturation:</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">4</property>
+                            <property name="top-attach">5</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSpinButton" id="sdr-saturation">
+                            <property name="can-focus">True</property>
+                            <property name="no-show-all">True</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">5</property>
+                            <property name="top-attach">5</property>
                           </packing>
                         </child>
                         <child>
@@ -406,7 +478,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
-                            <property name="top-attach">5</property>
+                            <property name="top-attach">6</property>
                             <property name="width">4</property>
                           </packing>
                         </child>
@@ -478,7 +550,7 @@
                           </object>
                           <packing>
                             <property name="left-attach">3</property>
-                            <property name="top-attach">5</property>
+                            <property name="top-attach">6</property>
                             <property name="width">5</property>
                           </packing>
                         </child>
@@ -572,6 +644,12 @@
                             <property name="top-attach">4</property>
                             <property name="width">2</property>
                           </packing>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
                         </child>
                         <child>
                           <placeholder/>

--- a/nwg_displays/settings_applier/settings_applier.py
+++ b/nwg_displays/settings_applier/settings_applier.py
@@ -77,6 +77,9 @@ class SettingsApplier:
             if d.get("ten_bit"):
                 line += ",bitdepth,10"
 
+            if d.get("cm") != "srgb":
+                line += f"cm,{d.get('cm')},sdrbrightness,{d.get('sdr_brightness')}, sdrsaturation, {d.get('sdr_saturation')}"
+            
             lines.append(line)
 
             if d["transform"] != "normal":
@@ -307,6 +310,8 @@ class SettingsApplier:
                 line += ",mirror,{}".format(db.mirror)
             if db.ten_bit:
                 line += ",bitdepth,10"
+            if db.cm != "srgb":
+                line += f",cm,{db.cm},sdrbrightness,{db.sdr_brightness},sdrsaturation,{db.sdr_saturation}"
 
             lines.append(line)
             if db.transform != "normal":

--- a/nwg_displays/tools.py
+++ b/nwg_displays/tools.py
@@ -159,6 +159,10 @@ def list_outputs():
             outputs_dict[m["name"]]["focused"] = m["focused"]
             outputs_dict[m["name"]]["dpms"] = m["dpmsStatus"]
 
+            outputs_dict[m["name"]]["cm"] = m["colorManagementPreset"]
+            outputs_dict[m["name"]]["sdr_brightness"] = m["sdrBrightness"]
+            outputs_dict[m["name"]]["sdr_saturation"] = m["sdrSaturation"]
+
             outputs_dict[name]["modes"] = []
 
             for item in m["availableModes"]:


### PR DESCRIPTION
Description

This PR adds hdr support for hyprland

Key Changes
Added hdr support for hdr(hdr,hredid)
added sdr_saturation and sdr_brightness scales 
options visible only if using hyprland no sway
formatted using black
main edited using glade 3.4 
#92 