### PR TITLE
Fix empty Workspaces dialog on Hyprland (missing 'global' declarations)

### DIFF
--- a/nwg_displays/main.py
+++ b/nwg_displays/main.py
@@ -666,7 +666,7 @@ def on_toggle_button(btn):
 
 
 def create_display_buttons():
-    global display_buttons
+    global display_buttons, outputs
     for item in display_buttons:
         item.destroy()
     display_buttons = []
@@ -1205,6 +1205,7 @@ def main():
             eprint("niri config directory not found!")
             outputs_path = ""
 
+    global num_ws
     num_ws = args.num_ws
     if sway:
         print("[Info] Number of workspaces: {}".format(num_ws))


### PR DESCRIPTION
Fixes #127.

Two assignments rebound module-level names inside functions without declaring them `global`, so the Workspaces dialog read stale defaults:

- `main()`: `num_ws = args.num_ws` was local, leaving the module-level `num_ws = 0`. The dialog grid rendered zero rows.
- `create_display_buttons()`: `outputs = list_outputs()` was local, leaving the module-level `outputs = {}`. The per-workspace combo boxes were empty so no monitor could be assigned.

Adding `global num_ws` and `global outputs` (alongside the existing `global display_buttons`) restores the expected behaviour. Verified locally on Hyprland with three connected outputs: the dialog now shows the configured number of rules and the combo boxes list all outputs.