### PR TITLE
refactor: extract duplicated writable-check logic into ensure_writable()

### DIFF
--- a/nwg_displays/main.py
+++ b/nwg_displays/main.py
@@ -1066,6 +1066,35 @@ def restore_old_settings(btn, backup, path):
         GLib.timeout_add(2000, create_display_buttons)
 
 
+def ensure_writable(path):
+    """Ensure the file at path is writable, replacing read-only symlinks if necessary."""
+    if not os.path.lexists(path):
+        return
+    is_writable = os.access(path, os.W_OK)
+    if os.path.islink(path) and not is_writable:
+        eprint(f"INFO: '{path}' is a read-only symlink. Replacing with a writable file.")
+        tmp_path = f"{path}.tmp"
+        try:
+            with open(path, 'r') as src_file, open(tmp_path, 'w') as tmp_file:
+                tmp_file.write(src_file.read())
+            backup_path = f"{path}.bkp"
+            counter = 1
+            while os.path.lexists(backup_path):
+                backup_path = f"{path}.bkp{counter}"
+                counter += 1
+            eprint(f"INFO: Backing up '{path}' to '{backup_path}'")
+            os.rename(path, backup_path)
+            os.rename(tmp_path, path)
+        except Exception as e:
+            eprint(f"ERROR: Failed to replace read-only symlink: {e}")
+    elif not os.path.islink(path) and not is_writable:
+        eprint(f"INFO: '{path}' is a read-only file. Making it writable.")
+        try:
+            os.chmod(path, os.stat(path).st_mode | stat.S_IWUSR)
+        except Exception as e:
+            eprint(f"ERROR: Failed to make file writable: {e}")
+            
+
 def main():
     GLib.set_prgname("nwg-displays")
 
@@ -1147,8 +1176,6 @@ def main():
     )
     args = parser.parse_args()
 
-    load_vocabulary()
-
     global outputs_path
     global workspaces_path
     if sway:
@@ -1160,32 +1187,7 @@ def main():
     elif hypr:
         if os.path.isdir(hypr_config_dir):
             outputs_path = args.monitors_path
-            # 97, 115
-            if os.path.lexists(outputs_path):
-                is_writable = os.access(outputs_path, os.W_OK)
-                if os.path.islink(outputs_path) and not is_writable:
-                    eprint(f"INFO: '{outputs_path}' is a read-only symlink. Replacing with a writable file.")
-                    tmp_path = f"{outputs_path}.tmp"
-                    try:
-                        with open(outputs_path, 'r') as src_file, open(tmp_path, 'w') as tmp_file:
-                            tmp_file.write(src_file.read())
-                        backup_path = f"{outputs_path}.bkp"
-                        counter = 1
-                        while os.path.lexists(backup_path):
-                            backup_path = f"{outputs_path}.bkp{counter}"
-                            counter += 1
-                        eprint(f"INFO: Backing up '{outputs_path}' to '{backup_path}'")
-                        os.rename(outputs_path, backup_path)
-                        os.rename(tmp_path, outputs_path)
-                    except Exception as e:
-                        eprint(f"ERROR: Failed to replace read-only symlink: {e}")
-                elif not os.path.islink(outputs_path) and not is_writable:
-                    eprint(f"INFO: '{outputs_path}' is a read-only file. Making it writable.")
-                    try:
-                        os.chmod(outputs_path, os.stat(outputs_path).st_mode | stat.S_IWUSR)
-                    except Exception as e:
-                        eprint(f"ERROR: Failed to make file writable: {e}")
-
+            ensure_writable(outputs_path)
             workspaces_path = args.workspaces_path
         else:
             eprint("Hyprland config directory not found!")
@@ -1194,34 +1196,11 @@ def main():
     elif niri:
         if os.path.isdir(niri_config_dir):
             outputs_path = args.monitors_path
-            # Check if file is writable
-            if os.path.lexists(outputs_path):
-                is_writable = os.access(outputs_path, os.W_OK)
-                if os.path.islink(outputs_path) and not is_writable:
-                    eprint(f"INFO: '{outputs_path}' is a read-only symlink. Replacing with a writable file.")
-                    tmp_path = f"{outputs_path}.tmp"
-                    try:
-                        with open(outputs_path, 'r') as src_file, open(tmp_path, 'w') as tmp_file:
-                            tmp_file.write(src_file.read())
-                        backup_path = f"{outputs_path}.bkp"
-                        counter = 1
-                        while os.path.lexists(backup_path):
-                            backup_path = f"{outputs_path}.bkp{counter}"
-                            counter += 1
-                        eprint(f"INFO: Backing up '{outputs_path}' to '{backup_path}'")
-                        os.rename(outputs_path, backup_path)
-                        os.rename(tmp_path, outputs_path)
-                    except Exception as e:
-                        eprint(f"ERROR: Failed to replace read-only symlink: {e}")
-                elif not os.path.islink(outputs_path) and not is_writable:
-                    eprint(f"INFO: '{outputs_path}' is a read-only file. Making it writable.")
-                    try:
-                        os.chmod(outputs_path, os.stat(outputs_path).st_mode | stat.S_IWUSR)
-                    except Exception as e:
-                        eprint(f"ERROR: Failed to make file writable: {e}")
+            ensure_writable(outputs_path)
         else:
             eprint("niri config directory not found!")
             outputs_path = ""
+
 
     global num_ws
     num_ws = args.num_ws


### PR DESCRIPTION
Cool repo! 

I noticed that the same ~20-line block appeared identically in both the hypr and niri branches of main(), so I extracted the duplicated symlink/file handling logic in main() into a helper function  called ensure_writable().

I'm happy to make any changes if necessary. Hope this helps! 