### PR TITLE
Fix monitor descriptions with hashes in hyprland lua config

### DIFF
--- a/nwg_displays/settings_applier/settings_applier.py
+++ b/nwg_displays/settings_applier/settings_applier.py
@@ -59,15 +59,14 @@ class SettingsApplier:
         print(f"[Profile] Applying {len(displays)} displays for Hyprland...")
 
         header = SettingsApplier._get_header("Profile Loader")
-        lines_conf = [header]
+        lines_conf = []
         lines_lua = [header.replace("#", "--")]
 
         for d in displays:
             if not use_desc:
                 name = d["name"]
             else:
-                desc_safe = d["description"].replace("#", "##")
-                name = f"desc:{desc_safe}"
+                name = f"desc:{d['description']}"
 
             lua_props = [f'    output = "{name}"']
 
@@ -120,6 +119,8 @@ class SettingsApplier:
             if outputs_path.endswith(".conf")
             else "~/.config/hypr/monitors.lua"
         )
+
+        lines_conf = [header] + [ln.replace("#", "##") for ln in lines_conf]
 
         save_list_to_text_file(lines_conf, outputs_path)
         save_list_to_text_file(lines_lua, outputs_path_lua)
@@ -426,15 +427,11 @@ class SettingsApplier:
         }
 
         header = SettingsApplier._get_header()
-        lines_conf = [header]
+        lines_conf = []
         lines_lua = [header.replace("#", "--")]
 
         for db in display_buttons:
-            name = (
-                db.name
-                if not use_desc
-                else "desc:{}".format(db.description.replace("#", "##"))
-            )
+            name = db.name if not use_desc else "desc:{}".format(db.description)
 
             lua_props = [f'    output = "{name}"']
 
@@ -487,6 +484,8 @@ class SettingsApplier:
         backup_lua = []
         if os.path.isfile(outputs_path_lua):
             backup_lua = load_text_file(outputs_path_lua).splitlines()
+
+        lines_conf = [header] + [ln.replace("#", "##") for ln in lines_conf]
 
         save_list_to_text_file(lines_conf, outputs_path)
         save_list_to_text_file(lines_lua, outputs_path_lua)


### PR DESCRIPTION
In #75, a guard mechanism against hashes in the monitor description was introduced.
The new Lua configuration uses the same guarded value as the description.
This makes the generated Lua configuration ineffective because the guard mechanism now changes the description, as the Hyprlang parser does not remove it.

The tool remains usable if the user turns off `Use Description` in the UI.  

This pull request only applies the guard mechanism to the old .conf lines.
I assumed that the hyprlang configuration generation does not place intentional comments anywhere other than the header. 