### PR TITLE
Fix disabled niri output detection

### DIFF
--- a/nwg_displays/tools.py
+++ b/nwg_displays/tools.py
@@ -154,11 +154,23 @@ def list_outputs():
             
             for name, mon in monitors_dict.items():
                 # Get current mode info
-                current_mode_idx = mon.get("current_mode", 0)
                 modes_list = mon.get("modes", [])
-                current_mode = modes_list[current_mode_idx] if modes_list and current_mode_idx < len(modes_list) else {}
-                
-                logical = mon.get("logical", {})
+                current_mode_idx = mon.get("current_mode")
+                logical = mon.get("logical")
+                active = current_mode_idx is not None and logical is not None
+
+                if active and 0 <= current_mode_idx < len(modes_list):
+                    current_mode = modes_list[current_mode_idx]
+                else:
+                    # Disabled niri outputs have no current mode or logical
+                    # geometry. Keep them available in the GUI using their
+                    # preferred mode (or the first advertised mode).
+                    current_mode = next(
+                        (mode for mode in modes_list if mode.get("is_preferred")),
+                        modes_list[0] if modes_list else {},
+                    )
+
+                logical = logical or {}
                 
                 # Store raw make/model for accurate matching (not just description)
                 raw_make = mon.get("make", "")
@@ -170,8 +182,8 @@ def list_outputs():
                 description = f'{raw_make} {raw_model} {raw_serial or ""}'.strip()
                 
                 outputs_dict[name] = {
-                    "active": True,  # If it's in the list, it's active
-                    "dpms": True,
+                    "active": active,
+                    "dpms": active,
                     "description": description,
                     "x": int(logical.get("x", 0)),
                     "y": int(logical.get("y", 0)),

--- a/tests/test_niri_outputs.py
+++ b/tests/test_niri_outputs.py
@@ -1,0 +1,58 @@
+import json
+import os
+import unittest
+from unittest.mock import Mock, patch
+
+from nwg_displays.tools import list_outputs
+
+
+class EmptyDisplay:
+    def get_n_monitors(self):
+        return 0
+
+
+class NiriOutputsTest(unittest.TestCase):
+    @patch("nwg_displays.tools.Gdk.Display.get_default", return_value=EmptyDisplay())
+    @patch("nwg_displays.tools.subprocess.run")
+    def test_disabled_output_with_null_current_mode(self, run, _get_default):
+        run.return_value = Mock(
+            stdout=json.dumps(
+                {
+                    "eDP-1": {
+                        "name": "eDP-1",
+                        "make": "LG Display",
+                        "model": "0x07BF",
+                        "serial": "0x0000FFA1",
+                        "physical_size": [300, 190],
+                        "modes": [
+                            {
+                                "width": 1920,
+                                "height": 1200,
+                                "refresh_rate": 60001,
+                                "is_preferred": True,
+                            }
+                        ],
+                        "current_mode": None,
+                        "vrr_supported": True,
+                        "vrr_enabled": False,
+                        "logical": None,
+                    }
+                }
+            )
+        )
+
+        with patch.dict(os.environ, {"NIRI_SOCKET": "/tmp/niri.sock"}, clear=False):
+            outputs = list_outputs()
+
+        output = outputs["eDP-1"]
+        self.assertFalse(output["active"])
+        self.assertFalse(output["dpms"])
+        self.assertEqual(output["physical-width"], 1920)
+        self.assertEqual(output["physical-height"], 1200)
+        self.assertEqual(output["refresh"], 60.001)
+        self.assertEqual(output["logical-width"], 0)
+        self.assertEqual(output["logical-height"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #139.

Niri reports disabled outputs with `current_mode: null` and `logical: null`. The current parser compares the null mode index with the mode-list length, which raises a `TypeError` and causes `list_outputs()` to return an empty dictionary.

This change:

- marks outputs without a current mode/logical geometry as inactive;
- keeps disabled outputs available in the GUI;
- uses the preferred advertised mode (or first mode as fallback) for their display properties;
- adds a regression test covering a disabled Niri output.

Tested with:

- `python -m unittest discover -s tests -v`
- live `niri msg -j outputs` data containing two active external outputs and one disabled laptop panel.