### PR TITLE
niri: honor use-desc setting when writing monitor.kdl

### DIFF
--- a/nwg_displays/settings_applier/settings_applier.py
+++ b/nwg_displays/settings_applier/settings_applier.py
@@ -162,6 +162,20 @@ class SettingsApplier:
             WallpaperManager.apply_wallpapers(profile_data["wallpapers"])
 
     @staticmethod
+    def _niri_output_name(name, description):
+        """
+        Return the match key to use for an output section in monitor.kdl.
+
+        niri matches outputs by connector name, or by "make model serial" with
+        missing parts spelled "Unknown" (see niri OutputName::matches). A
+        description with an unknown make/model (e.g. laptop panels) can never
+        match, so keep the connector name in that case.
+        """
+        if description and not description.startswith("Unknown"):
+            return description
+        return name
+
+    @staticmethod
     def _apply_niri_json(displays, use_desc, outputs_path, profile_data):
         """Apply niri configuration by writing monitor.kdl file"""
         print(f"[Profile] Applying {len(displays)} displays for niri...")
@@ -169,6 +183,8 @@ class SettingsApplier:
         kdl_data = []
         for d in displays:
             name = d["name"]
+            if use_desc:
+                name = SettingsApplier._niri_output_name(name, d.get("description"))
             
             display_config = {
                 "name": name,
@@ -402,8 +418,11 @@ class SettingsApplier:
         
         kdl_data = []
         for db in display_buttons:
+            name = db.name
+            if use_desc:
+                name = SettingsApplier._niri_output_name(name, db.description)
             display_config = {
-                "name": db.name,
+                "name": name,
                 "active": db.name not in outputs_activity or outputs_activity.get(db.name, True),
                 "physical_width": db.physical_width,
                 "physical_height": db.physical_height,

--- a/nwg_displays/tools.py
+++ b/nwg_displays/tools.py
@@ -166,8 +166,11 @@ def list_outputs():
                 raw_serial = mon.get("serial")
                 physical_size = mon.get("physical_size", [])
                 
-                # Format description for backward compatibility
-                description = f'{raw_make} {raw_model} {raw_serial or ""}'.strip()
+                # Format description for backward compatibility.
+                # niri matches outputs by "make model serial" (see OutputName::matches);
+                # a missing serial must be spelled out as "Unknown" for the
+                # description to work as a match key.
+                description = f'{raw_make} {raw_model} {raw_serial or "Unknown"}'
                 
                 outputs_dict[name] = {
                     "active": True,  # If it's in the list, it's active


### PR DESCRIPTION
## Problem

The niri backend ignores the **Use description** setting and always writes output sections matched by connector name:

```kdl
output "DP-1" { ... }
```

The `use_desc` parameter is passed into `_apply_niri_json` / `_apply_niri_gui` but never used — `save_kdl_output` receives `d["name"]` either way. (The sway backend honors it since `name = d["description"] if use_desc else d["name"]`.) This means the generated `monitor.kdl` breaks whenever monitors appear on different connectors, e.g. when moving a laptop between docks or hot desks — a common laptop scenario for niri users.

## Fix

With `use-desc` enabled, write the output match key as `make model serial` (what `niri msg outputs` reports and niri natively matches), falling back to the connector name where the description cannot match:

```kdl
output "Philips Consumer Electronics Company PHL 276E8V 0x00000984" {
    mode "3840x2160@59.997"
    scale 1.5
    position x=4520 y=0
}
```

Two niri-specific details (from niri's `OutputName::matches` in `niri-config/src/output.rs`):

1. **A missing serial must be spelled `Unknown`.** niri matches the literal string `"make model serial"` with missing parts replaced by `Unknown`. The previous description format stripped the empty serial (`f'{make} {model} {serial or ""}'.strip()`), producing `"make model"` — which niri silently never matches. The description built in `list_outputs()` now emits `make model Unknown` for serial-less monitors.
2. **Unknown make/model can never match.** Per niri's own tests, `"unknown unknown unknown"` matches nothing, so laptop panels (make/model = `Unknown`) keep their connector name (`eDP-1`), which is also the more sensible match key for a built-in display.

## Testing

Tested on niri 26.04 with a 3 external monitors + laptop panel setup:

- Profile-apply path (`_apply_niri_json`) and GUI apply path (`_apply_niri_gui`) with `use-desc: true` produce description-matched `output` sections and keep `output "eDP-1"` for the laptop panel.
- Generated sections verified against live `niri msg outputs`: niri applies the layout correctly after reload, and the config keeps working after moving monitors between connectors.
- Old profiles saved with the previous description format (`"Unknown Unknown"` for eDP, no-serial format for others) fall back gracefully to connector names.